### PR TITLE
Replace Principal Moment loop calculation with vectorized NumPy operations

### DIFF
--- a/src/python/calculate.py
+++ b/src/python/calculate.py
@@ -311,7 +311,7 @@ class Calculate(object):
             uk, ak = numpy.linalg.eig(I)
             order = uk.argsort()
             uk = uk[order]
-            ak = ak[order]
+            ak = ak[:, order]
 
         operate.Move.translate(self, frame, com, point=True)
 

--- a/src/python/calculate.py
+++ b/src/python/calculate.py
@@ -293,36 +293,6 @@ class Calculate(object):
 
         operate.Move.center(self, frame)
 
-        '''
-        Ixx = 0.0
-        Iyy = 0.0
-        Izz = 0.0
-        Ixy = 0.0
-        Ixz = 0.0
-        Iyz = 0.0
-        Iyx = 0.0
-        Izx = 0.0
-        Izy = 0.0
-
-        for i in range(self._natoms):
-
-            xp = self._coor[frame, i, 0]
-            yp = self._coor[frame, i, 1]
-            zp = self._coor[frame, i, 2]
-
-            Ixx = Ixx + self._mass[i] * (yp * yp + zp * zp)
-            Iyy = Iyy + self._mass[i] * (xp * xp + zp * zp)
-            Izz = Izz + self._mass[i] * (xp * xp + yp * yp)
-
-            Ixy = Ixy - self._mass[i] * xp * yp
-            Ixz = Ixz - self._mass[i] * xp * zp
-            Iyz = Iyz - self._mass[i] * yp * zp
-            Iyx = Iyx - self._mass[i] * yp * xp
-            Izx = Izx - self._mass[i] * zp * xp
-            Izy = Izy - self._mass[i] * zp * yp
-
-        I = numpy.array([[Ixx, Ixy, Ixz], [Iyx, Iyy, Iyz], [Izx, Izy, Izz]])
-        '''
         n_atoms = self._natoms
         m = self._mass.reshape(n_atoms, -1)
         m_coor = m * self._coor[frame]

--- a/src/python/calculate.py
+++ b/src/python/calculate.py
@@ -293,6 +293,7 @@ class Calculate(object):
 
         operate.Move.center(self, frame)
 
+        '''
         Ixx = 0.0
         Iyy = 0.0
         Izz = 0.0
@@ -321,6 +322,13 @@ class Calculate(object):
             Izy = Izy - self._mass[i] * zp * yp
 
         I = numpy.array([[Ixx, Ixy, Ixz], [Iyx, Iyy, Iyz], [Izx, Izy, Izz]])
+        '''
+        n_atoms = self._natoms
+        m = self._mass.reshape(n_atoms, -1)
+        m_coor = m * self._coor[frame]
+        m_coor2 = numpy.dot(self._coor[frame].T, m_coor)
+        numpy.fill_diagonal(m_coor2, m_coor2.diagonal() - m_coor2.trace())
+        I = -m_coor2
 
         if numpy.linalg.matrix_rank(I) < 3:
             print("You are requesting the pmi calculation for a singular system.")


### PR DESCRIPTION
This addresses #66 by replacing the loop using NumPy matrix multiplication.  These changes produce the same results but much faster.  I timed the code before and after this change (iterating 100x to get a reasonable average) for 2 different molecules on 2 computers, giving the following results:

| Machine | System | Original (s) | Vectorized (s) | Speed-up |
| ----------------- | ------ | ------------- | ------------- |------------- |
| AMD X4 965 | mAb | 0.173502459526  |  0.00427374839783 | 40x |
| MacBook Pro | mAb | 0.108209969997  | 0.00162575006485  |  67x |
| AMD X4 965 | 4x167 NCP | 0.853358361721  |  0.0248510980606 | 34x |
| MacBook Pro | 4x167 NCP | 0.555229699612  | 0.00928428173065  |  60x |


This is the code I used for testing
```
import os
import time
import sasmol.system as system

# pdb_fname = '4x167_ncp.pdb'
pdb_fname = 'aligned_mab.pdb'
n = 100

assert os.path.exists(pdb_fname), 'no such file: {}'.format(pdb_fname)
mol = system.Molecule(pdb_fname)

tic = time.time()
for i in range(n):
    mol.calculate_principal_moments_of_inertia(0)
toc = time.time() - tic

print('{} principal momement calculations of {} took {} seconds'.format(
    n, pdb_fname, toc))
print('{} s per iteration'.format(toc / n))
```